### PR TITLE
kind of fix scrolling iphone

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -158,8 +158,9 @@ a {
 
 html,
 body {
-  width: 100%;
+  background-color: black;
   height: 100%;
+  width: 100%;
 }
 
 /* main app styling */

--- a/src/components/Slider.vue
+++ b/src/components/Slider.vue
@@ -4,7 +4,7 @@
 				left: () => swipe('swipeleft'),
 				right: () => swipe('swiperight'),
 			}"
-    v-hammer:swipe.up.down="(event) => swipe(event.type)"
+    <!-- v-hammer:swipe.up.down="(event) => swipe(event.type)" -->
   >
     <swiper ref="mySwiper" :options="swiperOption" v-bind:class="{ active: isExpanded }">
       <swiper-slide v-for="slide in slides" :key="slide.id">

--- a/src/views/Model.vue
+++ b/src/views/Model.vue
@@ -199,8 +199,8 @@ export default {
 /* container for the model viewer */
 .model-viewer {
   width: 100%;
-  position: relative;
   max-height: 100vh;
+  position: fixed;
 
   /* background - to be able to set up background for the viewer, the model-gltf needs to have the backgroundAlpha propery set to 0  */
   background: #45484d; /* Old browsers */


### PR DESCRIPTION
not a fix but it is enhancing iphone scrolling problems with background.
On iphone the background (the model-viewer) is still scrolling while content of sliders is expanded, `position: fixed` on class .model-viewer fixes this.
Also v-hammer swipe up & down for sliders content-expanded is disabled due to scrolling problems.